### PR TITLE
Set Reply#guest_state default in after_initialize

### DIFF
--- a/app/controllers/replies_controller.rb
+++ b/app/controllers/replies_controller.rb
@@ -59,7 +59,7 @@ class RepliesController < ApplicationController
     if request.format == :xml
       params[:reply][:send_signup_confirmation] = false if params[:reply][:send_signup_confirmation].nil?
     end
-    reply_params = params[:reply].merge(guest_state: "unknown")
+    reply_params = params[:reply]
     @reply = @event.replies.new(reply_params)
     
     respond_to do |format|

--- a/app/models/reply.rb
+++ b/app/models/reply.rb
@@ -26,7 +26,13 @@ class Reply < ActiveRecord::Base
       transition :reminded => :expired
     end
   end
-  
+
+  after_initialize :set_default_guest_state
+
+  def set_default_guest_state
+    self.guest_state ||= 'unknown'
+  end
+
   def cancel!
     self.update_attributes!(guest_state: "cancelled")
   end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -30,7 +30,6 @@ end
 Factory.define(:reply) do |r|
   r.email "foo@example.org"
   r.name "Kalle Testson"
-  r.guest_state "unknown"
 end
 
 Factory.define(:mail_template) do |t|

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -71,14 +71,14 @@ describe Event do
   
   it "should be full if it has more than max_guest guests" do
     event = Event.create!(@valid_params.with(:max_guests => 1))
-    event.replies.create!(guest_state: "unknown", :name => 'Kalle', :email => 'kalle@example.org', :ticket_type => mock_model(TicketType))
+    event.replies.create!(:name => 'Kalle', :email => 'kalle@example.org', :ticket_type => mock_model(TicketType))
     
     expect(event).to be_full
   end
   
   it "should not be full with max_guests = 1 and one cancelled reply" do
     event = Event.create!(@valid_params.with(:max_guests => 1))
-    reply = event.replies.create!(guest_state: "unknown", :name => 'Kalle', :email => 'kalle@example.org', :ticket_type => mock_model(TicketType))
+    reply = event.replies.create!(:name => 'Kalle', :email => 'kalle@example.org', :ticket_type => mock_model(TicketType))
     reply.cancel!
     
     expect(event).not_to be_full

--- a/spec/models/reply_spec.rb
+++ b/spec/models/reply_spec.rb
@@ -16,7 +16,6 @@ describe Reply do
       :name => 'Kalle Anka',
       :email => 'kalle@example.org',
       :ticket_type => @ticket_type,
-      guest_state: "unknown",
     }
     
     @reply = Reply.new(@valid_attributes)
@@ -98,7 +97,7 @@ describe Reply do
     end
     
     it "should send payment registration mail when there is a payment_registered mail template" do
-      @reply = @event.replies.create!(guest_state: "unknown", :ticket_type => @ticket_type, :name => 'Kalle', :email => 'kalle@example.org')
+      @reply = @event.replies.create!(:ticket_type => @ticket_type, :name => 'Kalle', :email => 'kalle@example.org')
     
       allow(@event).to receive(:send_mail_for?).with(:payment_registered).and_return(true)
     


### PR DESCRIPTION
When initializing a new `Reply` object, the `guest_state` field will be
conditionally set to `'unknown'` unless it was provided on initialization.